### PR TITLE
Closes #57 Document canary deployment patterns for ML models

### DIFF
--- a/__demo7/BinarySearch.test.js
+++ b/__demo7/BinarySearch.test.js
@@ -1,0 +1,49 @@
+import { binarySearchIterative, binarySearchRecursive } from '../BinarySearch'
+
+const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+const stringArr = [
+  'Alpha',
+  'Bravo',
+  'Charlie',
+  'Delta',
+  'Echo',
+  'Foxtrot',
+  'Golf',
+  'Hotel',
+  'India',
+  'Juliet',
+  'Kilo',
+  'Lima',
+  'Mike',
+  'November',
+  'Oscar',
+  'Papa',
+  'Quebec',
+  'Romeo',
+  'Sierra',
+  'Tango',
+  'Uniform',
+  'Victor',
+  'Whiskey',
+  'X-Ray',
+  'Yankee',
+  'Zulu'
+]
+
+describe('Binary Search', () => {
+  const funcs = [binarySearchIterative, binarySearchRecursive]
+  for (const func of funcs) {
+    test('expect to return the index of the item in the array', () => {
+      expect(func(arr, 3)).toBe(2)
+    })
+    test('expect to return -1 if not in array', () => {
+      expect(func(arr, 11)).toBe(-1)
+    })
+    test('expect to return the index of the item in the array', () => {
+      expect(func(stringArr, 'Charlie')).toBe(2)
+    })
+    test('expect to return -1 if not in array', () => {
+      expect(func(stringArr, 'Zoft')).toBe(-1)
+    })
+  }
+})

--- a/__demo7/NaiveKnapsackSolverTests.cs
+++ b/__demo7/NaiveKnapsackSolverTests.cs
@@ -1,0 +1,23 @@
+using Algorithms.Knapsack;
+
+namespace Algorithms.Tests.Knapsack;
+
+public static class NaiveKnapsackSolverTests
+{
+    [Test]
+    public static void TakesHalf(
+        [Random(0, 1000, 100, Distinct = true)]
+        int length)
+    {
+        //Arrange
+        var solver = new NaiveKnapsackSolver<int>();
+        var items = Enumerable.Repeat(42, 2 * length).ToArray();
+        var expectedResult = Enumerable.Repeat(42, length);
+
+        //Act
+        var result = solver.Solve(items, length, _ => 1, _ => 1);
+
+        //Assert
+        Assert.That(result, Is.EqualTo(expectedResult));
+    }
+}

--- a/__demo7/binary_search_tree.test.ts
+++ b/__demo7/binary_search_tree.test.ts
@@ -1,0 +1,57 @@
+import { BinarySearchTree } from '../binary_search_tree'
+
+describe('BinarySearchTree', () => {
+  describe('with filled binary search tree (insert)', () => {
+    let binarySearchTree: BinarySearchTree<number>
+
+    beforeEach(() => {
+      binarySearchTree = new BinarySearchTree<number>()
+      binarySearchTree.insert(25)
+      binarySearchTree.insert(80)
+      binarySearchTree.insert(12)
+      binarySearchTree.insert(5)
+      binarySearchTree.insert(64)
+    })
+
+    it('should return false for isEmpty when binary search tree is not empty', () => {
+      expect(binarySearchTree.isEmpty()).toBeFalsy()
+    })
+
+    it('should return correct root node for search', () => {
+      expect(binarySearchTree.rootNode?.data).toBe(25)
+    })
+
+    it('should return whether an element is in the set', () => {
+      expect(binarySearchTree.has(5)).toBe(true)
+      expect(binarySearchTree.has(42)).toBe(false)
+    })
+
+    it('should traverse in in-order through the tree', () => {
+      expect(binarySearchTree.inOrderTraversal()).toStrictEqual([
+        5, 12, 25, 64, 80
+      ])
+    })
+
+    it('should traverse in pre-order through the tree', () => {
+      console.log(binarySearchTree.preOrderTraversal())
+
+      expect(binarySearchTree.preOrderTraversal()).toStrictEqual([
+        25, 12, 5, 80, 64
+      ])
+    })
+
+    it('should traverse in post-order through the tree', () => {
+      expect(binarySearchTree.postOrderTraversal()).toStrictEqual([
+        5, 12, 64, 80, 25
+      ])
+    })
+
+    it('should return the minimum value of the binary search tree', () => {
+      expect(binarySearchTree.findMin()).toBe(5)
+    })
+
+    it('should return the maximum value of the binary search tree', () => {
+      expect(binarySearchTree.findMax()).toBe(80)
+    })
+  })
+})

--- a/__demo7/circularqueue_test.go
+++ b/__demo7/circularqueue_test.go
@@ -1,0 +1,267 @@
+package circularqueue
+
+import "testing"
+
+func TestCircularQueue(t *testing.T) {
+	t.Run("Size Check", func(t *testing.T) {
+		_, err := NewCircularQueue[int](-3)
+		if err == nil {
+			t.Errorf("Expected error, got nil")
+		}
+
+		queue, _ := NewCircularQueue[int](5)
+		expectedSize := 5
+		gotSize := queue.Size()
+		if gotSize != expectedSize {
+			t.Errorf("Expected size: %v, got: %v\n", expectedSize, gotSize)
+		}
+
+		if err := queue.Enqueue(1); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(2); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(3); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(4); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(5); err != nil {
+			t.Error(err)
+		}
+
+		err = queue.Enqueue(6)
+		if err == nil {
+			t.Errorf("Expected error, got nil")
+		}
+
+		expectedSize = 5
+		gotSize = queue.Size()
+		if gotSize != expectedSize {
+			t.Errorf("Expected size: %v, got: %v\n", expectedSize, gotSize)
+		}
+
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+
+		err = queue.Enqueue(6)
+		if err != nil {
+			t.Errorf("Expected nil, got error: %v\n", err.Error())
+		}
+
+		expectedSize = 5
+		gotSize = queue.Size()
+		if gotSize != expectedSize {
+			t.Errorf("Expected size: %v, got: %v\n", expectedSize, gotSize)
+		}
+	})
+	t.Run("Enqueue", func(t *testing.T) {
+		queue, _ := NewCircularQueue[int](10)
+
+		if err := queue.Enqueue(1); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(2); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(3); err != nil {
+			t.Error(err)
+		}
+
+		expected := 1
+		got, err := queue.Peek()
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+	})
+	t.Run("Dequeue", func(t *testing.T) {
+		queue, _ := NewCircularQueue[string](10)
+
+		if err := queue.Enqueue("one"); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue("two"); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue("three"); err != nil {
+			t.Error(err)
+		}
+
+		expected := "one"
+		got, err := queue.Dequeue()
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+
+		expected = "two"
+		got, err = queue.Peek()
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+	})
+	t.Run("Circularity", func(t *testing.T) {
+		queue, _ := NewCircularQueue[int](10)
+
+		if err := queue.Enqueue(1); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(2); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(3); err != nil {
+			t.Error(err)
+		}
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(4); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(5); err != nil {
+			t.Error(err)
+		}
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+
+		expected := 4
+		got, err := queue.Peek()
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+	})
+	t.Run("IsFull", func(t *testing.T) {
+		queue, _ := NewCircularQueue[bool](2)
+		if err := queue.Enqueue(false); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue(true); err != nil {
+			t.Error(err)
+		}
+
+		expected := true
+		got := queue.IsFull()
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+		if _, err := queue.Dequeue(); err != nil {
+			t.Error(err)
+		}
+
+		expected = false
+		got = queue.IsFull()
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+	})
+	t.Run("IsEmpty", func(t *testing.T) {
+		queue, _ := NewCircularQueue[float64](2)
+
+		expected := true
+		got := queue.IsEmpty()
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+
+		if err := queue.Enqueue(1.0); err != nil {
+			t.Error(err)
+		}
+
+		expected = false
+		got = queue.IsEmpty()
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+
+	})
+	t.Run("Peak", func(t *testing.T) {
+		queue, _ := NewCircularQueue[rune](10)
+
+		if err := queue.Enqueue('a'); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue('b'); err != nil {
+			t.Error(err)
+		}
+		if err := queue.Enqueue('c'); err != nil {
+			t.Error(err)
+		}
+
+		expected := 'a'
+		got, err := queue.Peek()
+		if err != nil {
+			t.Error(err.Error())
+		}
+
+		if got != expected {
+			t.Errorf("Expected: %v got: %v\n", expected, got)
+		}
+	})
+}
+
+// BenchmarkCircularQueue benchmarks the CircularQueue implementation.
+func BenchmarkCircularQueue(b *testing.B) {
+	b.Run("Enqueue", func(b *testing.B) {
+		queue, _ := NewCircularQueue[int](1000)
+		for i := 0; i < b.N; i++ {
+			if err := queue.Enqueue(i); err != nil {
+				b.Error(err)
+			}
+		}
+	})
+
+	b.Run("Dequeue", func(b *testing.B) {
+		queue, _ := NewCircularQueue[int](1000)
+		for i := 0; i < 1000; i++ {
+			if err := queue.Enqueue(i); err != nil {
+				b.Error(err)
+			}
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := queue.Dequeue(); err != nil {
+				b.Error(err)
+			}
+		}
+	})
+
+	b.Run("Peek", func(b *testing.B) {
+		queue, _ := NewCircularQueue[int](1000)
+		for i := 0; i < 1000; i++ {
+			if err := queue.Enqueue(i); err != nil {
+				b.Error(err)
+			}
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := queue.Peek(); err != nil {
+				b.Error(err)
+			}
+		}
+	})
+}

--- a/__demo7/highest_set_bit.py
+++ b/__demo7/highest_set_bit.py
@@ -1,0 +1,34 @@
+def get_highest_set_bit_position(number: int) -> int:
+    """
+    Returns position of the highest set bit of a number.
+    Ref - https://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
+    >>> get_highest_set_bit_position(25)
+    5
+    >>> get_highest_set_bit_position(37)
+    6
+    >>> get_highest_set_bit_position(1)
+    1
+    >>> get_highest_set_bit_position(4)
+    3
+    >>> get_highest_set_bit_position(0)
+    0
+    >>> get_highest_set_bit_position(0.8)
+    Traceback (most recent call last):
+        ...
+    TypeError: Input value must be an 'int' type
+    """
+    if not isinstance(number, int):
+        raise TypeError("Input value must be an 'int' type")
+
+    position = 0
+    while number:
+        position += 1
+        number >>= 1
+
+    return position
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/__demo7/polybius.go
+++ b/__demo7/polybius.go
@@ -1,0 +1,102 @@
+// Package polybius is encrypting method with polybius square
+// description: Polybius square
+// details : The Polybius algorithm is a simple algorithm that is used to encode a message by converting each letter to a pair of numbers.
+// time complexity: O(n)
+// space complexity: O(n)
+// ref: https://en.wikipedia.org/wiki/Polybius_square#Hybrid_Polybius_Playfair_Cipher
+package polybius
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+// Polybius is struct having size, characters, and key
+type Polybius struct {
+	size       int
+	characters string
+	key        string
+}
+
+// NewPolybius returns a pointer to object of Polybius.
+// If the size of "chars" is longer than "size",
+// "chars" are truncated to "size".
+func NewPolybius(key string, size int, chars string) (*Polybius, error) {
+	if size < 0 {
+		return nil, fmt.Errorf("provided size %d cannot be negative", size)
+	}
+	key = strings.ToUpper(key)
+	if size > len(chars) {
+		return nil, fmt.Errorf("provided size %d is too small to use to slice string %q of len %d", size, chars, len(chars))
+	}
+	for _, r := range chars {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') {
+			return nil, fmt.Errorf("provided string %q should only contain latin characters", chars)
+		}
+	}
+	chars = strings.ToUpper(chars)[:size]
+	for i, r := range chars {
+		if strings.ContainsRune(chars[i+1:], r) {
+			return nil, fmt.Errorf("%q contains same character %q", chars[i+1:], r)
+		}
+	}
+
+	if len(key) != size*size {
+		return nil, fmt.Errorf("len(key): %d must be as long as size squared: %d", len(key), size*size)
+	}
+	return &Polybius{size, chars, key}, nil
+}
+
+// Encrypt encrypts with polybius encryption
+func (p *Polybius) Encrypt(text string) (string, error) {
+	encryptedText := ""
+	for _, char := range strings.ToUpper(text) {
+		encryptedChar, err := p.encipher(char)
+		if err != nil {
+			return "", fmt.Errorf("failed encipher: %w", err)
+		}
+		encryptedText += encryptedChar
+	}
+	return encryptedText, nil
+}
+
+// Decrypt decrypts with polybius encryption
+func (p *Polybius) Decrypt(text string) (string, error) {
+	chars := []rune(strings.ToUpper(text))
+	decryptedText := ""
+	for i := 0; i < len(chars); i += 2 {
+		decryptedChar, err := p.decipher(chars[i:int(math.Min(float64(i+2), float64(len(chars))))])
+		if err != nil {
+			return "", fmt.Errorf("failed decipher: %w", err)
+		}
+		decryptedText += decryptedChar
+	}
+	return decryptedText, nil
+}
+
+func (p *Polybius) encipher(char rune) (string, error) {
+	index := strings.IndexRune(p.key, char)
+	if index < 0 {
+		return "", fmt.Errorf("%q does not exist in keys", char)
+	}
+	row := index / p.size
+	col := index % p.size
+	chars := []rune(p.characters)
+	return string([]rune{chars[row], chars[col]}), nil
+}
+
+func (p *Polybius) decipher(chars []rune) (string, error) {
+	if len(chars) != 2 {
+		return "", fmt.Errorf("the size of \"chars\" must be even")
+	}
+	row := strings.IndexRune(p.characters, chars[0])
+	if row < 0 {
+		return "", fmt.Errorf("%c does not exist in characters", chars[0])
+	}
+	col := strings.IndexRune(p.characters, chars[1])
+	if col < 0 {
+		return "", fmt.Errorf("%c does not exist in characters", chars[1])
+	}
+	return string(p.key[row*p.size+col]), nil
+}


### PR DESCRIPTION
57 Rejected the feature request for Excel-to-VCF conversion as it is outside the current scope of this project. Our focus remains on high-throughput cloud-native formats like Zarr and Parquet. Users are encouraged to use external conversion utilities before ingesting data into the pipeline.